### PR TITLE
 Fix meatballssc and sausagecooked blueprint bug

### DIFF
--- a/_metadata
+++ b/_metadata
@@ -7,5 +7,5 @@
   "name" : "StarchefREDUX",
   "requires" : [],
   "steamContentId" : "922187979",
-  "version" : "1.0.4"
+  "version" : "1.0.5"
 }

--- a/items/generic/starchef/meatballssc.consumable
+++ b/items/generic/starchef/meatballssc.consumable
@@ -21,5 +21,6 @@
   "rottingMultiplier" : 1.0,
   "blockingEffects" : [
     "wellfed"
-  ]
+  ],
+  "learnBlueprintsOnPickup" : [ "meatballsbbq" ] 
 }

--- a/items/generic/starchef/sausagecooked.consumable
+++ b/items/generic/starchef/sausagecooked.consumable
@@ -14,6 +14,7 @@
   "rottingMultiplier" : 0.5,
   "blockingEffects" : [
     "wellfed"
-  ]
+  ],
+  "learnBlueprintsOnPickup" : [ "corndogsc", "hotdogsc", "eggsxsausage", "pizzasosg" ] 
 }
 


### PR DESCRIPTION
Re-adds the missing blueprints for meatballssc and sausagecooked consumables.